### PR TITLE
Add direct message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ______________________________________________________________________
   - [Use Doctrines From Fittings Module](#use-doctrines-from-fittings-module)
   - [Webhook Verification](#webhook-verification)
   - [Default Embed Color](#default-embed-color)
+  - [Direct Messages](#direct-messages)
 - [Changelog](#changelog)
 - [Translation Status](#translation-status)
 - [Contributing](#contributing)
@@ -178,6 +179,12 @@ The default highlight for the embed, that is used when no other highlight color 
 defined.
 
 **Default:** #FAA61A
+
+### Direct Messages<a name="direct-messages"></a>
+
+Enable sending pings as a Discord direct message to the user who submitted the ping.
+
+**Default:** False
 
 ## Changelog<a name="changelog"></a>
 

--- a/fleetpings/form.py
+++ b/fleetpings/form.py
@@ -89,6 +89,12 @@ class FleetPingForm(forms.Form):
         widget=forms.Select(choices={}),
         help_text=_("Select a channel to ping automatically."),
     )
+    direct_message = forms.BooleanField(
+        initial=False,
+        required=False,
+        label=_("Direct message"),
+        help_text=_("Send this ping as a direct message to you."),
+    )
     fleet_type = forms.CharField(
         required=False, label=_("Fleet type"), widget=forms.Select(choices={})
     )

--- a/fleetpings/helper/discord_dm.py
+++ b/fleetpings/helper/discord_dm.py
@@ -1,0 +1,68 @@
+"""Send Discord Direct Messages."""
+
+from __future__ import annotations
+
+# Standard Library
+import logging
+from typing import Any
+
+import requests
+from django.conf import settings
+from django.contrib.auth.models import User
+
+from fleetpings.constants import APP_NAME, GITHUB_URL
+from fleetpings.helper.eve_images import get_character_portrait_from_evecharacter
+from fleetpings.helper.ping_context import _get_webhook_ping_context
+
+try:
+    from allianceauth.services.modules.discord.models import DiscordUser
+except Exception:  # pragma: no cover - allianceauth not available
+    DiscordUser = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def ping_discord_dm(ping_context: dict[str, Any], user: User) -> None:
+    """Send a direct message with fleet ping details to the given user."""
+
+    if DiscordUser is None:
+        logger.warning("Discord service not installed, cannot send DM")
+        return
+
+    token = getattr(settings, "FLEETPINGS_BOT_TOKEN", None)
+    if not token:
+        logger.warning("FLEETPINGS_BOT_TOKEN not configured")
+        return
+
+    try:
+        discord_user = DiscordUser.objects.get(user=user)
+    except Exception as ex:  # pragma: no cover - external lib
+        logger.warning("Could not find Discord user for %s: %s", user, ex)
+        return
+
+    headers = {
+        "Authorization": f"Bot {token}",
+        "User-Agent": f"{APP_NAME} ({GITHUB_URL})",
+        "Content-Type": "application/json",
+    }
+
+    # Create DM channel
+    response = requests.post(
+        "https://discord.com/api/v10/users/@me/channels",
+        json={"recipient_id": str(discord_user.uid)},
+        headers=headers,
+        timeout=10,
+    )
+    response.raise_for_status()
+    channel_id = response.json()["id"]
+
+    webhook_ping_context = _get_webhook_ping_context(ping_context=ping_context)
+    message = f"{webhook_ping_context['header']}\n{webhook_ping_context['content']}"
+
+    send_resp = requests.post(
+        f"https://discord.com/api/v10/channels/{channel_id}/messages",
+        json={"content": message},
+        headers=headers,
+        timeout=10,
+    )
+    send_resp.raise_for_status()

--- a/fleetpings/helper/ping_context.py
+++ b/fleetpings/helper/ping_context.py
@@ -102,6 +102,7 @@ def get_ping_context_from_form_data(form_data: dict) -> dict:
         },
         "create_optimer": bool(form_data["optimer"]),
         "additional_information": str(form_data["additional_information"]),
+        "send_dm": bool(form_data.get("direct_message")),
         "timezones_installed": timezones_installed(),
         "optimer_installed": optimer_installed(),
         "fittings_installed": fittings_installed(),

--- a/fleetpings/locale/django.pot
+++ b/fleetpings/locale/django.pot
@@ -420,6 +420,14 @@ msgstr ""
 msgid "Default highlight color for the webhook embed."
 msgstr ""
 
+#: fleetpings/form.py:94
+msgid "Direct message"
+msgstr ""
+
+#: fleetpings/form.py:95
+msgid "Send this ping as a direct message to you."
+msgstr ""
+
 #: fleetpings/models.py:627
 msgid "Setting"
 msgstr ""

--- a/fleetpings/tests/test_helper_discord_dm.py
+++ b/fleetpings/tests/test_helper_discord_dm.py
@@ -1,0 +1,25 @@
+"""Tests for the discord_dm helper."""
+
+# Standard Library
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+# Alliance Auth (External Libs)
+from app_utils.testing import create_fake_user
+
+# AA Fleet Pings
+from fleetpings.helper.discord_dm import ping_discord_dm
+
+
+class TestDiscordDM(TestCase):
+    """Test sending a discord DM."""
+
+    @patch("fleetpings.helper.discord_dm.requests.post")
+    @patch("fleetpings.helper.discord_dm.DiscordUser")
+    def test_ping_discord_dm(self, mock_discord_user, mock_post):
+        user = create_fake_user()
+        mock_discord_user.objects.get.return_value.uid = "1234"
+
+        ping_discord_dm(ping_context={"ping_channel": {"webhook": None}}, user=user)
+
+        self.assertTrue(mock_post.called)

--- a/fleetpings/views.py
+++ b/fleetpings/views.py
@@ -35,6 +35,7 @@ from fleetpings.app_settings import (
     use_fittings_module_for_doctrines,
 )
 from fleetpings.form import FleetPingForm
+from fleetpings.helper.discord_dm import ping_discord_dm
 from fleetpings.helper.discord_webhook import ping_discord_webhook
 from fleetpings.helper.ping_context import get_ping_context_from_form_data
 from fleetpings.models import (
@@ -485,6 +486,10 @@ def ajax_create_fleet_ping(request: WSGIRequest) -> HttpResponse:
             # If we have a Discord webhook, ping it
             if ping_context["ping_channel"]["webhook"]:
                 ping_discord_webhook(ping_context=ping_context, user=request.user)
+
+            # Send as direct message if requested
+            if ping_context.get("send_dm"):
+                ping_discord_dm(ping_context=ping_context, user=request.user)
 
             logger.info(msg=f"Fleet ping created by user {request.user}")
 


### PR DESCRIPTION
## Summary
- allow sending pings as a Discord DM
- document the direct message option
- support new form field and ping context
- implement DM helper
- test DM helper

## Testing
- `pre-commit run --files README.md fleetpings/form.py fleetpings/helper/ping_context.py fleetpings/locale/django.pot fleetpings/views.py fleetpings/helper/discord_dm.py fleetpings/tests/test_helper_discord_dm.py` *(fails: `pre-commit: command not found`)*
- `python runtests.py` *(fails: ModuleNotFoundError: No module named 'django')*

------